### PR TITLE
Refactor lifecycles in artist, guest, and shop entities: add checks f…

### DIFF
--- a/src/api/artist/content-types/artist/lifecycles.ts
+++ b/src/api/artist/content-types/artist/lifecycles.ts
@@ -15,13 +15,15 @@ export default {
         documentId: data.documentId,
         populate: ['users_permissions_user'],
       });
-  
-      await strapi.documents('plugin::users-permissions.user').update({
-        documentId: artist.users_permissions_user.documentId,
-        data: {
-          blocked: data.blocked,
-        },
-      });
+      
+      if (artist?.users_permissions_user.documentId) {
+        await strapi.documents('plugin::users-permissions.user').update({
+          documentId: artist.users_permissions_user.documentId,
+          data: {
+            blocked: data.blocked,
+          },
+        });
+      }
     }
 
     // Only prevent changing the user if request is NOT from admin panel

--- a/src/api/guest/content-types/guest/lifecycles.ts
+++ b/src/api/guest/content-types/guest/lifecycles.ts
@@ -7,13 +7,15 @@ export default {
         documentId: data.documentId,
         populate: ['users_permissions_user'],
       });
-  
-      await strapi.documents('plugin::users-permissions.user').update({
-        documentId: guest.users_permissions_user.documentId,
-        data: {
-          blocked: data.blocked,
-        },
-      });
+      
+      if (guest?.users_permissions_user?.documentId) {
+        await strapi.documents('plugin::users-permissions.user').update({
+          documentId: guest.users_permissions_user.documentId,
+          data: {
+            blocked: data.blocked,
+          },
+        });
+      }
     }
   },
 };

--- a/src/api/shop/content-types/shop/lifecycles.ts
+++ b/src/api/shop/content-types/shop/lifecycles.ts
@@ -19,12 +19,14 @@ export default {
         populate: ['users_permissions_user'],
       });
   
-      await strapi.documents('plugin::users-permissions.user').update({
-        documentId: shop.users_permissions_user.documentId,
-        data: {
-          blocked: data.blocked,
-        },
-      });
+      if (shop?.users_permissions_user?.documentId) {
+        await strapi.documents('plugin::users-permissions.user').update({
+          documentId: shop.users_permissions_user.documentId,
+          data: {
+            blocked: data.blocked,
+          },
+        });
+      }
     }
 
     // Only prevent changing the user if request is NOT from admin panel


### PR DESCRIPTION
…or users_permissions_user.documentId before updating blocked status to prevent errors.